### PR TITLE
feat: Implement lives, game over, and improved score display

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -9,20 +9,23 @@
 
 class Game {
 public:
-    Game();
+    Game(); // Initialize lives to 3 here
     void start();
     void update();
     void render();
     bool isRunning() const;
 
 private:
+    void renderGameOver(); // Method to render game over screen
     bool running;
+    bool gameOver; // Game over state
+    int lives; // Player lives
     Player player;
     std::vector<Enemy> enemies;
     std::vector<Bullet> playerBullets;
     std::vector<Bullet> enemyBullets;
     std::vector<Explosion> explosions; // Track explosions
-    int deathCount; // Track the number of times the player has died
+    // int deathCount; // Track the number of times the player has died - Replaced by lives
     int enemyKillCount; // Track the number of enemies killed
     int spawnCounter; // Counter to control enemy spawning
     static const int spawnInterval = 50; // Interval to spawn new enemies


### PR DESCRIPTION
This commit introduces several gameplay enhancements:

- Player Lives:
  - Players now have a set number of lives (defaulting to 3).
  - Each time the player is hit by an enemy bullet, a life is lost.
  - The game ends when you run out of lives.

- Game Over State:
  - When lives reach zero, the game transitions to a "Game Over" screen.
  - This screen displays your final score (enemies killed).
  - You can quit the game from the Game Over screen by pressing 'Q'.

- Scoreboard Update:
  - The in-game scoreboard now displays remaining lives and the number of enemies killed.
  - The previous `deathCount` metric has been removed in favor of the lives system.

- Code Refinements:
  - `Game::isRunning()` now more accurately reflects the active game state by considering the `gameOver` flag.
  - `Game::update()` includes safeguards to prevent game logic from running when the game is over.